### PR TITLE
Add new output message for daily prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![NPM Total Downloads](https://img.shields.io/npm/dt/node-red-contrib-nordpool-api-plus.svg)](https://www.npmjs.com/package/node-red-contrib-nordpool-api-plus)
 [![Dependencies](https://img.shields.io/librariesio/release/npm/node-red-contrib-nordpool-api-plus.svg)](https://libraries.io/github/zinen/node-red-contrib-nordpool-api-plus)
 
-A Node-Red Node for collecting "day ahead" prices from Nord Pool Group.
+A Node-Red Node for collecting "day ahead" prices from Nord Pool Group.  
+Hourly and daily prices are retrieved.
 
 *This is a fork of the original node-red-contrib-nordpool-api, but with source code on github to make pull request possible and issue handling. Later that year: the original code is now [uploaded here](https://github.com/Csstenersen/node-red-contrib-nordpool-api)*
 
@@ -27,7 +28,12 @@ Use a inject node to trigger a request to nordpool, to get prices for today.
 
 Its also possible to inject a `msg.date` to get price from a specific date, or pricing for tomorrow. If you request tomorrows data before 14:42 there's a risk that data is not available yet and you will get the data from the current date. See [API issue#1](https://github.com/samuelmr/nordpool-node/issues/1#issuecomment-316583765)
 
-An 24 object long array is returned on success. The objects contains this properties: `timestamp`, `price`, `currency` and `area`.
+Hourly and daily prices are returned on separate outputs.
+
+Hourly prices are returned in a 24 object long array on success.  
+Daily prices are returned in an array 31 objects long (i.e. roughly for the past month).
+
+Objects for hourly and daily prices have the same properties: `timestamp`, `price`, `currency` and `area`.  
 
 ![](/img/example3.png)
 

--- a/nordpool-api-plus.html
+++ b/nordpool-api-plus.html
@@ -8,11 +8,15 @@
             currency: {Value:"EUR"},
         },
         inputs:1,
-        outputs:1,
+        outputs:2,
         icon: "white-globe.png",
         label: function() {
             return this.name ||"nordpool-api+";
-        }
+        },
+        outputLabels: [
+            "Hourly prices",
+            "Daily prices"
+        ]
     });
 </script>
 
@@ -85,8 +89,9 @@
             If not defined in input todays date will be used.  If you request tomorrows data before 14:42 theres risk that data is not available yet and you will get the data from the current date. See <a href="https://github.com/samuelmr/nordpool-node/issues/1#issuecomment-316583765" target="_blank">API issue#1</a>.
         </dd>
     </dl>
-    <h3>Output</h3>
-    <p>Returns an array with 24 objects.</p>
+    <h3>Outputs</h3>
+    <p>There are two outputs, one for hourly prices and one for daily prices.</p>
+    <p>Each output returns an array of objects.<br>Each object contains the following fields:</p>
     <dl class="message-properties">
         <dt>timestamp
             <span class="property-type">timestamp</span>


### PR DESCRIPTION
Great little Node-RED node, good work.

As I had a need for daily prices in addition to hourly ditto, I made some changes to the code base:

1. A new output for daily prices. 
2. Added labels ("Hourly prices" and "Daily prices") to both outputs. These show when hoovering over the outputs in the Node-RED editor.
3. Added separate node status messages for errors getting hourly/daily data.
4. Added a few lines in the Node-RED doc page about the fact that there are two outputs. Also changed the previous statement about the output array containing 24 objects (it can contain more, up to 31 I think).
5. Added a few empty lines here and there in the JS file to make it a bit more readable. To my eyes at least... :)

It just struck me that I should update the README too. Will do that after creating this PR. 